### PR TITLE
Rename `in` class to `show` to handle Bootstrap 4 Alpha 6 and above

### DIFF
--- a/src/dialog-holder.component.ts
+++ b/src/dialog-holder.component.ts
@@ -49,7 +49,7 @@ export class DialogHolderComponent {
       this.dialogs.push(_component);
     }
     setTimeout(()=>{
-      dialogWrapper.container.nativeElement.classList.add('in')
+      dialogWrapper.container.nativeElement.classList.add('show')
     });
     return _component.fillData(data);
   }
@@ -61,7 +61,7 @@ export class DialogHolderComponent {
   removeDialog(component:DialogComponent) {
     let element = component.wrapper.container.nativeElement;
 
-    element.classList.remove('in');
+    element.classList.remove('show');
     setTimeout(() => {
         this._removeElement(component);
     }, 300);


### PR DESCRIPTION
The latest Bootstrap 4 Alpha 6 has changed the classes used in dropdown's and modal's. Specifically the class `in` has now been renamed to `show`.

Refer to the [v4 Alpha 6 ship list](https://github.com/twbs/bootstrap/issues/20939) for more details on what's changed.

The following PR handles the new classes for the latest Bootstrap 4 onwards.