### PR TITLE
fix removeAll no dialogHolderComponent

### DIFF
--- a/src/dialog.service.ts
+++ b/src/dialog.service.ts
@@ -70,6 +70,9 @@ export class DialogService {
    * Closes all dialogs
    */
   removeAll(): void {
+    if(!this.dialogHolderComponent) {
+      return;
+    }
     this.dialogHolderComponent.clear();
   }
 


### PR DESCRIPTION
fix removeAll() when dialogHolderComponent has not been initialized, same situation is handled correctly in removeDialog()